### PR TITLE
Change CMake C++ standard to 11, require it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,10 @@
 cmake_minimum_required(VERSION 3.10)
 project(MilkyTracker)
 
-# Set C++ standard to C++98
-set(CMAKE_CXX_STANDARD 98)
+# Set C++ standard to C++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Enable IDE solution folders


### PR DESCRIPTION
Changed the CMake C++ standard line to use C++11 and made it required, as a step for #1

Compiling works again with RtMidi 5 now.